### PR TITLE
Update md_auto_resync.py

### DIFF
--- a/RAID1AutoRecovery/opt/hpe/lsrrb/bin/md_auto_resync.py
+++ b/RAID1AutoRecovery/opt/hpe/lsrrb/bin/md_auto_resync.py
@@ -152,6 +152,8 @@ def resync(new_disk):
     output, err = proc.communicate()
     output = output.decode()
     print(output, file =log)
+    bootentry_alive = ''
+    loader = ''
     for line in output.splitlines():
         if 'BootOrder' in line:
             orig_order = line[11:]


### PR DESCRIPTION
Hello there,

I want to make this change to avoid the following error when performing a rebuild to a new disk in Debian 10.12.

Error:
```
"UnboundLocalError: local variable 'bootentry_alive' referenced before assignment"
"UnboundLocalError: local variable 'loader' referenced before assignment"
```