### PR TITLE
Update shebang to use Python 3 - Update md_auto_resync.py

### DIFF
--- a/RAID1AutoRecovery/opt/hpe/lsrrb/bin/md_auto_resync.py
+++ b/RAID1AutoRecovery/opt/hpe/lsrrb/bin/md_auto_resync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # (c) Copyright [2017] Hewlett Packard Enterprise Development LP
 #
 # This program is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Update shebang to use Python 3

Changed the shebang line from `#!/usr/bin/env python` to `#!/usr/bin/env python3` to ensure the script runs with Python 3. This modification is necessary for compatibility with environments where the default `python` command points to Python 2, ensuring the script executes with the intended Python 3 interpreter.